### PR TITLE
removed /bagajob from homepage URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "http://develop-me.github.io/bagajob/",
+  "homepage": "http://develop-me.github.io/",
   "name": "frontend",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
**Issue:**

On `npm start` React-Router directs to `localhost:3000/bagajob` which does not exist and results in Error 404:

<img width="516" alt="Screenshot 2020-09-21 at 13 29 59" src="https://user-images.githubusercontent.com/52701889/93766717-ba168080-fc0e-11ea-8a40-0cd40285a070.png">

**Action:**

Change default URL on `npm start` to `localhost:3000`

**Result:**

On `npm start`, React Router directs to correct URL: `localhost:3000`

<img width="1338" alt="Screenshot 2020-09-21 at 13 36 54" src="https://user-images.githubusercontent.com/52701889/93767256-a4ee2180-fc0f-11ea-8ecb-58280a03550b.png">
