### PR TITLE
Single job loading

### DIFF
--- a/src/components/Job/Job.js
+++ b/src/components/Job/Job.js
@@ -24,7 +24,7 @@ const Job = ({ match }) => {
         }
         dispatch(getSingleJob(data));
     }, []);
-    console.log(access_token)
+
     // deletes single job
     const handleDeleteJob = () => {
         dispatch(deleteJob({

--- a/src/data/Jobs/actions.js
+++ b/src/data/Jobs/actions.js
@@ -100,7 +100,6 @@ const getJobFailure = data => dispatch => (
 export const addJob = data => dispatch => {
     return new Promise((resolve, reject) => {
         dispatch(addJobRequest())
-        console.log(data)
         apiAddJob(data)
             .then(successResponse => {
                 dispatch(addJobSuccess(successResponse))
@@ -155,7 +154,6 @@ const updateJobRequest = () => dispatch => (
 )
 
 const updateJobSuccess = data => dispatch => {
-    console.log(data.data.data)
     return (
         dispatch({
             type: SINGLE_JOB_PATCH_SUCCESS,

--- a/src/data/Jobs/reducer.js
+++ b/src/data/Jobs/reducer.js
@@ -40,7 +40,7 @@ export default (state, action) => {
         case SINGLE_JOB_GET_REQUEST:
             return {
                 ...state,
-
+                loaded: false
             }
         case SINGLE_JOB_GET_SUCCESS:
             return {


### PR DESCRIPTION
This branch is a secondary branch from `display-and-edit-jobs`:

`master` -> `development` -> `display-and-edit-jobs` -> `single-job-loading`

The purpose of this branch is to address an issue where the single job page would render the components before data has been fetched from the API, resulting in the browser displaying incorrect job details.

This has now been fixed by adding a `loaded` boolean to the reducer preventing component mount, which is not updated until data has been returned from the API.

Since all changes on `display-and-edit-jobs` will be reviewed before merge into `development`, this PR does not require approval.