### PR TITLE
Add collaboration instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ git push origin {branch}
 
 1. Visit the local development server in your browser
 
+## Developing Styling
+
+This application is styled using SASS. All `.scss` files (`src/scss/example/_example.scss`) are imported (`@import`) into `src/scss/main.scss`, before being compiled to `src/css/styles.min.css`.
+
+In order to compile SASS to CSS, run the following command in the project root:
+
+`sass src/scss/main.scss src/css/styles.min.css`
+
+In order to configure SASS to compile every time changes are saved to a SASS file, run:
+
+`sass --watch src/scss/main.scss src/css/styles.min.css`
+
+Please note that changes to SASS files will not show in the app until compiled to `src/css/styles.min.css`.
+
 ## API Set Up
 - To test the front end fully you'll need to set up a local instance of the API on a VM. Follow the instructions on this gitHub repo to install:
   - (https://github.com/develop-me/bagajob-api)


### PR DESCRIPTION
Issue:
- Instructions on collaboration workflow are outdated now that alpha release v0.0.1 has been deployed.

Action:
- Add these changes to the README, and merge these changes into `master` using the same methodology:
`feature-branch` --> `development` --> `master`

Note:
- The `development` branch is not usually merged to `master` until a new release and its features have been fully developed and tested. This rare exception of merging `development` into `master` without updating the server is made possible by no other changes being made other than to the documentation - and also because these changes in particular are needed on the `master` branch, in order to instruct new collaborators on the aforementioned workflow.
- These changes would normally be approved by another collaborator, but since these changes serve to provide further information about collaboration to collaborators, on this rare occasion this step has been skipped.
---
*Pre-approved by Maintainer*